### PR TITLE
Add new security header and update dependencies

### DIFF
--- a/.github/workflows/deploy-to-azure.yml
+++ b/.github/workflows/deploy-to-azure.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: npm setup
         working-directory: ui
-        run: npm install --force --ignore-scripts
+        run: npm install --frozen-lockfile --force --ignore-scripts
 
       - name: ui-angular-cli-build
         working-directory: ui

--- a/.github/workflows/dotnet-and-npm-build.yml
+++ b/.github/workflows/dotnet-and-npm-build.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: npm setup
         working-directory: ui
-        run: npm install --force --ignore-scripts
+        run: npm install --frozen-lockfile --force --ignore-scripts
 
       - name: ui-angular-cli-build
         working-directory: ui

--- a/Bff.AppHost/Bff.AppHost.csproj
+++ b/Bff.AppHost/Bff.AppHost.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Aspire.Hosting.AppHost" Version="13.3.3" />
-	<PackageReference Include="Aspire.Hosting.JavaScript" Version="13.3.3" />
+	<PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.6" />
+	<PackageReference Include="Aspire.Hosting.JavaScript" Version="13.4.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bff.ServiceDefaults/Bff.ServiceDefaults.csproj
+++ b/Bff.ServiceDefaults/Bff.ServiceDefaults.csproj
@@ -10,10 +10,10 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.6.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.6.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.7.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ ng update @angular/cli @angular/core
 
 ## History
 
+- 2026-06-24 Updated NuGet packages, added new security headers
 - 2026-05-16 Updated NuGet packages, updated Angular to 21.2.0
 - 2026-03-18 Updated .NET Aspire to 13.1.2, updated xunit to xunit.v3, moved permissions from workflow level to job level, updated npm packages
 - 2026-03-14 Updated Nuget packages

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ For local development environment setup proceed as follows:
 
 1. Check out the repository
 1. Install Angular CLI latest globally `npm install -g @angular/cli latest`
-1. Open `Bff.sln` in Visual Studio 2022 or later
+1. Open `Bff.sln` in Visual Studio 2026 or later
 1. Set `Bff.AppHost` as startup project
 1. Run the project (F5)
 1. Open URL of `bffmicrosoftentraid-server` from the Aspire dashboard (usually `https://localhost:5001`)

--- a/server/BffMicrosoftEntraID.Server.csproj
+++ b/server/BffMicrosoftEntraID.Server.csproj
@@ -21,12 +21,12 @@
 	</ItemGroup>
   
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.8" NoWarn="NU1605" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.8" />
-		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
-		<PackageReference Include="Microsoft.Identity.Web.GraphServiceClient" Version="4.9.0" />
-		<PackageReference Include="Microsoft.Identity.Web" Version="4.9.0" />
-		<PackageReference Include="Microsoft.Identity.Web.UI" Version="4.9.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.9" NoWarn="NU1605" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.9" />
+		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Identity.Web.GraphServiceClient" Version="4.11.0" />
+		<PackageReference Include="Microsoft.Identity.Web" Version="4.11.0" />
+		<PackageReference Include="Microsoft.Identity.Web.UI" Version="4.11.0" />
 		<PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" Version="1.3.1" />
 		<PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders.TagHelpers" Version="1.3.1" />
 		<PackageReference Include="Yarp.ReverseProxy" Version="2.3.0" />

--- a/server/Controllers/AccountController.cs
+++ b/server/Controllers/AccountController.cs
@@ -31,7 +31,7 @@ public class AccountController : ControllerBase
     [HttpPost("Logout")]
     public IActionResult Logout()
     {
-        Response.Headers.Append("Clear-Site-Data", "\"cache\", \"cookies\",\"executionContexts\"");
+        Response.Headers.Append("Clear-Site-Data", "\"cache\", \"cookies\"");
         return SignOut(
             new AuthenticationProperties { RedirectUri = "/" },
             CookieAuthenticationDefaults.AuthenticationScheme,

--- a/server/Controllers/AccountController.cs
+++ b/server/Controllers/AccountController.cs
@@ -31,6 +31,7 @@ public class AccountController : ControllerBase
     [HttpPost("Logout")]
     public IActionResult Logout()
     {
+        Response.Headers.Append("Clear-Site-Data", "\"cache\", \"cookies\",\"executionContexts\"");
         return SignOut(
             new AuthenticationProperties { RedirectUri = "/" },
             CookieAuthenticationDefaults.AuthenticationScheme,

--- a/tests/BffMicrosoftEntraID.Server.IntegrationTests.csproj
+++ b/tests/BffMicrosoftEntraID.Server.IntegrationTests.csproj
@@ -8,12 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 	<PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
**Dependency updates:**

* Upgraded NuGet packages in `Bff.AppHost.csproj`, `Bff.ServiceDefaults.csproj`, `BffMicrosoftEntraID.Server.csproj`, and `BffMicrosoftEntraID.Server.IntegrationTests.csproj` to the latest versions, including Aspire, Microsoft Identity Web, OpenTelemetry, and test-related packages. [[1]](diffhunk://#diff-1aab70fc9ed7f72f3095a3b470543736ecc9f82947c391c8dc51be85be6ed4d5L12-R13) [[2]](diffhunk://#diff-a33b5e1aaa820c90e0d0fe4a2e960583b4329b52d423d5069fd1f8d1be367172L13-R16) [[3]](diffhunk://#diff-401acaedda480640f7360c4a2f4bbb2564f4f42510a78c1125ca29b534c5d8f8L24-R29) [[4]](diffhunk://#diff-08caa555fb21a09e60b8f88ae0efaca351fb892d1669b69b7c7752012df3dbc6L11-R16)

**CI/CD workflow improvements:**

* Updated the npm install step in `.github/workflows/deploy-to-azure.yml` and `.github/workflows/dotnet-and-npm-build.yml` to use `--frozen-lockfile` for more reliable and reproducible builds. [[1]](diffhunk://#diff-cf18ecc07678667b850fbe0e904da1950658c22cbedd4dbd44d9a13283dd3726L50-R50) [[2]](diffhunk://#diff-df125f138db2e9191f629db5aa788da745c378dbbba5a9a2fd45c7ad83008e22L26-R26)

**Security Headers:**

* Added new security header `Clear-Site-Data` on logout

**Documentation:**

* Added an entry to `README.md` to record the dependency updates and mention the addition of new security headers.